### PR TITLE
Wrapped modules

### DIFF
--- a/hira/src/lib.rs
+++ b/hira/src/lib.rs
@@ -9,3 +9,13 @@ pub fn hira(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> pro
 pub fn hiracfg(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     item
 }
+
+#[proc_macro_attribute]
+pub fn hirawrap(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    item
+}
+
+#[proc_macro_attribute]
+pub fn hirawrapmod(_attr: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    item
+}

--- a/hira_lib/src/lib.rs
+++ b/hira_lib/src/lib.rs
@@ -532,7 +532,7 @@ pub fn use_hira_config(mut cb: impl FnMut(&mut HiraConfig)) {
 pub mod e2e_tests {
     use std::str::FromStr;
     use proc_macro2::TokenStream;
-    use crate::module_loading::{hira_mod2_inner};
+    use crate::module_loading::{hira_mod2_inner, ModuleLevel};
     use super::*;
 
     pub fn assert_contains_str<Q: AsRef<str>, S: AsRef<str>>(search: Q, contains: S) {
@@ -1152,6 +1152,56 @@ pub mod e2e_tests {
         assert_eq!(module.hiracfgs[0].applied_to, "");
     }
 
+    #[test]
+    fn mod2_hirawrapmod_works() {
+        let code = [
+            stringify!(
+                pub mod lvl2mod {
+                    use super::L0Core;
+                    #[derive(Default)]
+                    pub struct Input {
+                        pub has_error: bool,
+                    }
+                    pub fn config(input: &mut Input, c: &mut L0Core) {
+                        if input.has_error {
+                            c.compiler_error("somebody set has_error!");
+                        }
+                    }
+                }
+            ),
+            stringify!(
+                pub mod lvl2mod_higher {
+                    use super::lvl2mod;
+                    #[derive(Default)]
+                    pub struct Input {}
+                    pub fn config(input: &mut Input, other: &mut lvl2mod::Input) {}
+                }
+            ),
+            stringify!(
+                #[hirawrapmod(lvl2mod)]
+                pub mod lvl2mod_wrapper {
+                    use super::lvl2mod;
+                    pub fn config(input: &mut lvl2mod::Input) {
+                        input.has_error = true;
+                    }
+                }
+            ),
+            stringify!(
+                #[hirawrap(lvl2mod, lvl2mod_wrapper)]
+                pub mod mylevel3mod {
+                    use super::lvl2mod_higher;
+                    pub fn config(input: &mut lvl2mod_higher::Input) {}
+                }
+            ),
+        ];
+        let (conf, stream) = e2e_module2_run_with_token_stream(&code,|_| {}).expect("Failed to get conf");
+        let module = conf.get_mod2("lvl2mod_wrapper").expect("Failed to get lvl2mod wrapper");
+        assert_eq!(module.level, ModuleLevel::Level2);
+        assert_eq!(module.is_wrapper_of, Some("lvl2mod".to_string()));
+        let module = conf.get_mod2("mylevel3mod").expect("Failed to get mylevel3mod");
+        assert_eq!(module.use_wrappers.as_ref().unwrap()["lvl2mod"][0], "lvl2mod_wrapper");
+        assert_contains_str(stream.to_string(), "somebody set has_error!");
+    }
 
     #[test]
     fn mod2_fn_signature_not_provided_if_not_requested() {

--- a/hira_lib/src/module_loading.rs
+++ b/hira_lib/src/module_loading.rs
@@ -108,6 +108,15 @@ pub struct HiraModule2 {
 
     pub hiracfgs: Vec<Hiracfg>,
 
+    /// lvl2 modules that are wrappers of some other lvl2 modules
+    /// will have this field set.
+    pub is_wrapper_of: Option<String>,
+
+    /// lvl3 modules that are annotated with #[hirawrap(A, B)]
+    /// will have this field set where it will be Some(A -> [B, ]).
+    /// there can potentially be multiple wrappers per module.
+    pub use_wrappers: Option<HashMap<String, Vec<String>>>,
+
     /// during parsing we detect which outputs this module has in its use statements.
     /// prior to compiling, we fill in these outputs into the wasm code.
     pub fill_outputs: Vec<OutputType>,
@@ -546,7 +555,8 @@ impl HiraModule2 {
         // - if the signature input is a Self Input (ie &mut Input)
         //   then it must be a lvl2 module
         // - if the signature input is a lvl2 Input (ie &mut some_lvl2_mod::Input)
-        //   then it must be a lvl3 module
+        //   then check if it is a wrapper of some other lvl2 module, if so, this module is also lvl2.
+        //   if it is not a wrapper, then it must be a lvl3 module.
         // - if the signature input is a Level0 module (ie &mut L0...)
         //   then it is invalid, since only level2 modules can use Level0 modules
         //   and level2 modules must contain a Self Input first.
@@ -561,7 +571,9 @@ impl HiraModule2 {
             ));
         }
         if self.config_fn_signature_inputs.len() == 1 {
-            if self.config_fn_signature_inputs[0] == "& mut Input" {
+            if self.is_wrapper_of.is_some() {
+                self.level = ModuleLevel::Level2;
+            } else if self.config_fn_signature_inputs[0] == "& mut Input" {
                 self.level = ModuleLevel::Level2;
             } else if self.compile_dependencies.len() == 1 {
                 match self.compile_dependencies[0] {
@@ -591,24 +603,36 @@ impl HiraModule2 {
         }
 
         if self.level == ModuleLevel::Level2 {
-            if self.input_struct.is_empty() {
-                return Err(compiler_error(
-                    &format!("Detected module {} as {:?}, but it is missing an Input struct. All Level2 modules must contain an Input struct, and reference it in its config function signature", self.name, self.level)
-                ));
-            }
-            if !self.input_struct_has_default {
-                return Err(compiler_error(
-                    &format!("Module {} has an Input struct that is missing a Default implementation. Hira relies on Input structs having a default function. Add a default implementation by adding `#[derive(Default)]` above your input struct, or create a manual default implementation inside your module like `impl Default for Input {{ fn default() -> Self {{ ... }} }}`", self.name)
-                ));
-            }
-            if !self.config_fn_signature_inputs.iter().any(|x| x.contains("& mut Input")) {
-                return Err(compiler_error(
-                    &format!("Detected module {} as {:?}, but its config function signature does not reference its own Input struct. All Level2 modules must reference their Self Input in their config function signatures. Eg: `pub fn config(&mut Input)`", self.name, self.level)
-                ));
+            // if it is a wrapper lvl2 module, then we can skip these checks:
+            if self.is_wrapper_of.is_none() {
+                if self.input_struct.is_empty() {
+                    return Err(compiler_error(
+                        &format!("Detected module {} as {:?}, but it is missing an Input struct. All Level2 modules must contain an Input struct, and reference it in its config function signature", self.name, self.level)
+                    ));
+                }
+                if !self.input_struct_has_default {
+                    return Err(compiler_error(
+                        &format!("Module {} has an Input struct that is missing a Default implementation. Hira relies on Input structs having a default function. Add a default implementation by adding `#[derive(Default)]` above your input struct, or create a manual default implementation inside your module like `impl Default for Input {{ fn default() -> Self {{ ... }} }}`", self.name)
+                    ));
+                }
+                if !self.config_fn_signature_inputs.iter().any(|x| x.contains("& mut Input")) {
+                    return Err(compiler_error(
+                        &format!("Detected module {} as {:?}, but its config function signature does not reference its own Input struct. All Level2 modules must reference their Self Input in their config function signatures. Eg: `pub fn config(&mut Input)`", self.name, self.level)
+                    ));
+                }
             }
             if !self.is_pub {
                 return Err(compiler_error(
                     &format!("Detected module {} as {:?}, but it is not marked public. Level2 modules must be public", self.name, self.level)
+                ));
+            }
+        }
+
+        // if we are a wrapper of another lvl2 module, ensure it exists:
+        if let Some(other_lvl2) = &self.is_wrapper_of {
+            if conf.get_mod2(&other_lvl2).is_none() {
+                return Err(compiler_error(
+                    &format!("Module {} is a wrapper of {}, but {} has not been loaded yet. Ensure the module to be wrapped is loaded before declaring a wrapper of it", self.name, other_lvl2, other_lvl2)
                 ));
             }
         }

--- a/hira_lib/src/module_loading.rs
+++ b/hira_lib/src/module_loading.rs
@@ -806,6 +806,12 @@ pub fn hira_mod2_inner_ex(
         log_fn(&module.name);
     }
     module.insert_evaluated_outputs(conf)?;
+    // we also want to insert evaluated outputs for wrapper modules:
+    if let Some(wrapper_map) = &module.use_wrappers {
+        for (_, wrapper_names) in wrapper_map {
+            conf.insert_evaluated_outputs_for(wrapper_names)?;
+        }
+    }
     let codes = get_wasm_code_to_compile2(conf, &module)?;
     let extern_dependencies = get_all_extern_crates(conf, &mut module);
     let mut pass_this = LibraryObj::new();

--- a/hira_lib/src/wasm_types.rs
+++ b/hira_lib/src/wasm_types.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr};
+use std::{str::FromStr, collections::HashMap};
 
 use proc_macro2::{TokenStream};
 use wasm_type_gen::*;
@@ -97,7 +97,9 @@ pub fn get_wasm_code_to_compile2(
     let mut dependency_mod_defs = vec![];
 
     let l2_dep_name = hira_module_lvl3.level3_get_depends_on(hira_module_lvl3.lvl3_module_depends_on.as_ref())?;
-    let dependency_config = fill_dependency_config(hira_conf, &l2_dep_name, &mut dependency_mod_defs)?;
+    let use_wrappers_default = HashMap::new();
+    let use_wrappers = hira_module_lvl3.use_wrappers.as_ref().unwrap_or(&use_wrappers_default);
+    let dependency_config = fill_dependency_config(hira_conf, &l2_dep_name, &mut dependency_mod_defs, use_wrappers)?;
 
     let hira_base_code = hira_conf.hira_base_code.clone();
     let module_code = quote! {


### PR DESCRIPTION
given something like:

```rust
pub mod lvl2mod {
    pub struct Input {
        pub something: String,
        // lots of other stuff
    }
    pub fn config(...) {...}
}

pub mod lvl2_higher {
    pub struct Input {
        pub inner_settings: lvl2mod::Input,
        // other stuff
    }
    pub fn config(lvl2mod::Input) {...}
}
pub mod lvl3 {
    pub fn config(lvl2_higher::Input) {...}
}
```

it would be convenient for an end user to be able to customize lvl2mod behavior without needing to always have to set the inner settings of lvl2_higher. in fact, lvl2_higher might not even provide inner_settings, and instead only rely on the default passed to its config function.

a wrapper could allow an end user to customize lvl2mod behavior without needing to modify lvl2_higher, and could look as so:

```rust
#[hirawrapmod(lvl2mod)]
pub mod wrapper {
    pub fn config(inp: &mut lvl2mod::Input) { }
}

#[hira]
#[hirawrap(lvl2mod, wrapper)]
pub mod lvl3 {
    pub fn config(lvl2_higher::Input) {...}
}
```

what this will do is under the hood inside the wasm calling code, we will call in order:

```rust
let mut obj1 = lvl2_higher::Input::default();
let mut obj2 = lvl2mod::Input::default();
lvl3::config(&mut obj1);
lvl2_higher::config(&mut obj1, &mut obj2);
wrapper::config(&mut obj2); // this gets inserted to allow wrapping capabilities
lvl2mod::config(&mut obj2);
```